### PR TITLE
Added Bag Separation Feature

### DIFF
--- a/config/localization/cn.lua
+++ b/config/localization/cn.lua
@@ -46,6 +46,7 @@ L.LeftTabsTip = [[
 L.Appearance = '外观'
 L.Layer = '层级'
 L.BagBreak = '背包分散'
+L.BagBreakProfession = '职业'
 L.ReverseBags = '反向背包排列'
 L.ReverseSlots = '反向物品排列'
 

--- a/config/localization/en.lua
+++ b/config/localization/en.lua
@@ -46,6 +46,7 @@ displayed on the left side of the panel.]]
 L.Appearance = 'Appearance'
 L.Layer = 'Layer'
 L.BagBreak = 'Bag Break'
+L.BagBreakProfession = 'Professions'
 L.ReverseBags = 'Reverse Bag Order'
 L.ReverseSlots = 'Reverse Slot Order'
 

--- a/config/localization/es.lua
+++ b/config/localization/es.lua
@@ -45,6 +45,7 @@ se mostrarán en el lado izquierdo del panel.]]
 L.Appearance = 'Apariencia'
 L.Layer = 'Capa'
 L.BagBreak = 'Espacio entre bolsas'
+L.BagBreakProfession = 'Oficios'
 L.ReverseBags = 'Invertir bolsas'
 L.ReverseSlots = 'Invertir ranuras'
 

--- a/config/localization/fr.lua
+++ b/config/localization/fr.lua
@@ -45,6 +45,7 @@ L.ExclusiveReagent = 'Séparer la banque des composants'
 L.Appearance = 'Apparence'
 L.Layer = 'Couche'
 L.BagBreak = 'Séparation entre les sacs'
+L.BagBreakProfession = 'Métiers'
 L.ReverseBags = 'Inverser ordre des sacs'
 L.ReverseSlots = 'Inverser ordre de tri'
 

--- a/config/localization/it.lua
+++ b/config/localization/it.lua
@@ -44,6 +44,7 @@ Se abilitato, i pannelli laterali verranno mostrati a sinistra della finestra]]
 L.Appearance = 'Aspetto'
 L.Layer = 'Livello'
 L.BagBreak = 'Separazione tra Borse'
+L.BagBreakProfession = 'Mestieri'
 L.ReverseBags = 'Inverti le Borse'
 L.ReverseSlots = 'Inverti gli Scomparti'
 

--- a/config/localization/ko.lua
+++ b/config/localization/ko.lua
@@ -44,6 +44,7 @@ L.LeftTabsTip = [[
 L.Appearance = '모양'
 L.Layer = '레이어'
 L.BagBreak = '가방 별로 구분하여 표시'
+L.BagBreakProfession = '직업'
 L.ReverseBags = '가방 순서 반대로'
 L.ReverseSlots = '칸 순서 반대로'
 

--- a/config/localization/nl.lua
+++ b/config/localization/nl.lua
@@ -47,6 +47,7 @@ weergegeven aan de linkerkant van het paneel.]]
 L.Appearance = 'Uiterlijk'
 L.Layer = 'Laag'
 L.BagBreak = 'Tas Onderbreken'
+L.BagBreakProfession = 'Beroepen'
 L.ReverseBags = 'Omgekeerde Tasvolgorde'
 L.ReverseSlots = 'Omgekeerde Slotvolgorde'
 

--- a/config/localization/pt.lua
+++ b/config/localization/pt.lua
@@ -42,6 +42,7 @@ L.LeftTabsTip = 'Se ativado, os separadores laterais serão exibidos no lado esq
 L.Appearance = 'Aparência'
 L.Layer = 'Camada'
 L.BagBreak = 'Quebras entre Sacos'
+L.BagBreakProfession = 'Profissões'
 L.ReverseBags = 'Inverter Sacos'
 L.ReverseSlots = 'Inverter Itens'
 L.Color = 'Cor de Fundo'

--- a/config/localization/ru.lua
+++ b/config/localization/ru.lua
@@ -43,6 +43,7 @@ L.LeftTabsTip = [[
 L.Appearance = 'Внешний вид'
 L.Layer = 'Слой'
 L.BagBreak = 'Каждая сумка с новой строки'
+L.BagBreakProfession = 'Профессии'
 L.ReverseBags = 'Обратный порядок сумок'
 L.ReverseSlots = 'Обратный порядок ячеек'
 

--- a/config/localization/tw.lua
+++ b/config/localization/tw.lua
@@ -35,6 +35,7 @@ L.Options = '設定按鈕'
 L.Appearance = '外觀'
 L.Layer = '階層'
 L.BagBreak = '根據背包顯示'
+L.BagBreakProfession = '職業'
 L.ReverseBags = '反轉背包順序'
 L.ReverseSlots = '反轉槽位順序'
 

--- a/config/panels/frameOptions.lua
+++ b/config/panels/frameOptions.lua
@@ -66,7 +66,7 @@ function Frames:Populate()
 
 			self:AddCheck('reverseBags')
 			self:AddCheck('reverseSlots')
-			self:AddCheck('bagBreak')
+			-- self:AddCheck('bagBreak') -- old version
 
 			if REAGENTBANK_CONTAINER and self.frame == 'bank' then
 				self:AddCheck('exclusiveReagent')
@@ -83,6 +83,8 @@ function Frames:Populate()
       if Config.columns then
         self:AddSlider('columns', 1, 50)
       end
+        self:AddChoice{arg='bagBreak',{key='NONE',text=NONE},{key='PROFESSION',text = L.BagBreakProfession},{key='ALL',text=ALL}}
+
     end)
   end
 end

--- a/core/api/settings.lua
+++ b/core/api/settings.lua
@@ -34,6 +34,7 @@ local FrameDefaults = {
 	money = true, broker = true,
 	bagToggle = true, sort = true, search = true, options = true,
 
+	bagBreak = 'NONE',
 	strata = 'HIGH', alpha = 1,
 	scale = Addon.FrameScale or 1,
 	color = {0, 0, 0, 0.5},

--- a/core/classes/frameBase.lua
+++ b/core/classes/frameBase.lua
@@ -160,3 +160,19 @@ end
 function Frame:GetFrameID()
 	return self.id
 end
+
+function Frame:GetBagType(bag)
+	local data = self:GetOwner()[bag]
+	if data and data.link then
+		link, owned = 'item:' .. data.link, true
+		_, _, _, _, _, itemType, itemSubType,
+		_, _, _, _, _, subclassID, _,
+		_, _, isCraftingReagent = GetItemInfo(link)
+	else
+		itemType = nil
+		itemSubType = nil
+		subclassID = nil
+		isCraftingReagent = nil
+	end
+	return itemType,itemSubType,subclassID,isCraftingReagent
+end

--- a/core/classes/frameBase.lua
+++ b/core/classes/frameBase.lua
@@ -161,7 +161,7 @@ function Frame:GetFrameID()
 	return self.id
 end
 
-function Frame:GetBagType(bag)
+function Frame:GetBagInfo(bag)
 	local data = self:GetOwner()[bag]
 	if data and data.link then
 		link, owned = 'item:' .. data.link, true

--- a/core/classes/itemGroup.lua
+++ b/core/classes/itemGroup.lua
@@ -129,25 +129,21 @@ function Items:Layout()
 				end
 			end
 
-			if self:GetProfile().bagBreak ~= 'NONE' and x > 0 then
-				local itemType,itemSubType,subclassID,isCraftingReagent = self.frame:GetBagInfo(bag)
-				local currentBagType = subclassID  -- Supposons que subclassID représente le type de sac.
+			if self:GetProfile().bagBreak ~= 'NONE' and x > 0 then -- When bagBreak is not set to NONE
+				local _,_,subclassID,_ = self.frame:GetBagInfo(bag) -- Get the bag info
+				local currentBagType = subclassID
 				local nextBag = self.bags[k + 1]
 
-				if nextBag and self:GetProfile().bagBreak == 'PROFESSION' then
-					local itemType, itemSubType, subclassID, isCraftingReagent = self.frame:GetBagInfo(nextBag.id)
-					local currentBagType = subclassID  -- Supposons que subclassID représente le type de sac.
+				if nextBag and self:GetProfile().bagBreak == 'PROFESSION' then -- When bagBreak is set to Profession
+					local _, _, subclassID = self.frame:GetBagInfo(nextBag.id) -- Get the next bag info
+					local nextBagType = subclassID
 
-					-- Vérifiez si le type de sac change du sac précédent au sac suivant.
-					if previousBagType and previousBagType ~= currentBagType then
-						-- Il y a un changement de type de sac.
+					if currentBagType and currentBagType ~= nextBagType then
 						y = y + 1
 						x = 0
 					end
 
-					-- Mettez à jour la variable previousBagType pour le prochain tour de la boucle.
-					previousBagType = currentBagType
-				elseif nextBag and self:GetProfile().bagBreak == 'ALL' then
+				elseif nextBag and self:GetProfile().bagBreak == 'ALL' then -- When bagBreak is set to All
 					y = y + 1
 					x = 0
 				end

--- a/core/classes/itemGroup.lua
+++ b/core/classes/itemGroup.lua
@@ -86,6 +86,7 @@ function Items:Layout()
 	-- Acquire slots
 	for i, frame in ipairs(self.bags) do
 		local bag = frame.id
+
 		if self.frame:IsShowingBag(bag) then
 			for slot = 1, self.frame:NumSlots(bag) do
 				if self.frame:IsShowingItem(bag, slot) then
@@ -104,6 +105,7 @@ function Items:Layout()
 
 	local revBags, revSlots = profile.reverseBags, profile.reverseSlots
 	local x, y = 0,0
+	local previousBagType = nil
 
 	for k = revBags and #self.bags or 1, revBags and 1 or #self.bags, revBags and -1 or 1 do
 		local bag = self.bags[k].id
@@ -127,9 +129,28 @@ function Items:Layout()
 				end
 			end
 
-			if self:GetProfile().bagBreak and x > 0 then
-				y = y + 1
-				x = 0
+			if self:GetProfile().bagBreak ~= 'NONE' and x > 0 then
+				local itemType,itemSubType,subclassID,isCraftingReagent = self.frame:GetBagType(bag)
+				local currentBagType = subclassID  -- Supposons que subclassID représente le type de sac.
+				local nextBag = self.bags[k + 1]
+
+				if nextBag and self:GetProfile().bagBreak == 'PROFESSION' then
+					local itemType, itemSubType, subclassID, isCraftingReagent = self.frame:GetBagType(nextBag.id)
+					local currentBagType = subclassID  -- Supposons que subclassID représente le type de sac.
+
+					-- Vérifiez si le type de sac change du sac précédent au sac suivant.
+					if previousBagType and previousBagType ~= currentBagType then
+						-- Il y a un changement de type de sac.
+						y = y + 1
+						x = 0
+					end
+
+					-- Mettez à jour la variable previousBagType pour le prochain tour de la boucle.
+					previousBagType = currentBagType
+				elseif nextBag and self:GetProfile().bagBreak == 'ALL' then
+					y = y + 1
+					x = 0
+				end
 			end
 		end
 	end

--- a/core/classes/itemGroup.lua
+++ b/core/classes/itemGroup.lua
@@ -130,12 +130,12 @@ function Items:Layout()
 			end
 
 			if self:GetProfile().bagBreak ~= 'NONE' and x > 0 then
-				local itemType,itemSubType,subclassID,isCraftingReagent = self.frame:GetBagType(bag)
+				local itemType,itemSubType,subclassID,isCraftingReagent = self.frame:GetBagInfo(bag)
 				local currentBagType = subclassID  -- Supposons que subclassID représente le type de sac.
 				local nextBag = self.bags[k + 1]
 
 				if nextBag and self:GetProfile().bagBreak == 'PROFESSION' then
-					local itemType, itemSubType, subclassID, isCraftingReagent = self.frame:GetBagType(nextBag.id)
+					local itemType, itemSubType, subclassID, isCraftingReagent = self.frame:GetBagInfo(nextBag.id)
 					local currentBagType = subclassID  -- Supposons que subclassID représente le type de sac.
 
 					-- Vérifiez si le type de sac change du sac précédent au sac suivant.


### PR DESCRIPTION
## Changes Made
- Added a new setting for bag separation in the `config/panels/frameOptions.lua` file. This setting allows users to choose between no separation, separation by type (profession/reagent), or individual separation for each bag.
- Updated the `Layout` function in the `core/classes/itemGroup.lua` file to implement the bag separation logic based on the user's chosen setting.
- Implemented the `Frame:GetBagInfo(bag)` function in the `core/classes/frameBase.lua` file to retrieve the bag type information needed for the separation logic.

## Files Changed
- `config/panels/frameOptions.lua`
- `core/classes/itemGroup.lua`
- `core/classes/frameBase.lua`

## How to Test
1. Open the settings menu and navigate to the Window section then Appearance.
2. Select your preferred bag separation option from the new setting.
3. Open your bags to see the separation applied based on your chosen setting.
4. Test with different bag types (normal, profession / reagent) and multiple bags to ensure the separation is working as expected.

Please review the changes and provide any feedback or suggestions for improvement.